### PR TITLE
Corrected mapping of gains for TX

### DIFF
--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -350,6 +350,7 @@ void SoapyHackRF::setGain( const int direction, const size_t channel, const doub
 void SoapyHackRF::setGain( const int direction, const size_t channel, const std::string &name, const double value )
 {
 	std::lock_guard<std::mutex> lock(_device_mutex);
+	SoapySDR_logf(SOAPY_SDR_DEBUG,"setGain %s %s, channel %d, gain %d", name.c_str(), direction == SOAPY_SDR_RX ? "RX" : "TX", channel, (int)value);
 	if ( name == "AMP" )
 	{
 		_current_amp = value;

--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -260,7 +260,6 @@ std::vector<std::string> SoapyHackRF::listGains( const int direction, const size
 	{
 		options.push_back( "VGA" );						// TX: if_gain
 		options.push_back( "AMP" );						// TX: rf_gain
-		options.push_back( "LNA" );						// TX: bb_gain (not used on tx)
 	}
 
 	return(options);

--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -251,10 +251,17 @@ std::vector<std::string> SoapyHackRF::listGains( const int direction, const size
 	std::vector<std::string> options;
 	if ( direction == SOAPY_SDR_RX )
 	{
-		options.push_back( "LNA" );
+	// in gr-osmosdr/lib/soapy/ soapy_sink_c.cc and soapy_source_c.cc expect if_gain at front and bb_gain at back
+		options.push_back( "LNA" );						// RX: if_gain
+		options.push_back( "AMP" );						// RX: rf_gain
+		options.push_back( "VGA" );						// RX: bb_gain
 	}
-	options.push_back( "VGA" );
-	options.push_back( "AMP" );
+	else
+	{
+		options.push_back( "VGA" );						// TX: if_gain
+		options.push_back( "AMP" );						// TX: rf_gain
+		options.push_back( "LNA" );						// TX: bb_gain (not used on tx)
+	}
 
 	return(options);
 	/*


### PR DESCRIPTION
For the sink (TX) block, the gains were listed in the wrong order. The required order is implicitly set by the code in gr-osmosdr/lib/soapy. The changes correct the order for the sink, and add a debug statement to verify that the expected change is occurring. Tested with osmocom Source and Osmocom Sink blocks in gnuradio.

This fix corrects the mapping of IF_GAIN and BB_GAIN for both RX and TX, but does not provide any way to selectively set the AMP on or off, because that is part of the RF_GAIN distribution algorithm.
