### PR TITLE
Fixed usage of hackrf_amp_enable

### DIFF
--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -288,6 +288,7 @@ void SoapyHackRF::setGain( const int direction, const size_t channel, const doub
 	std::lock_guard<std::mutex> lock(_device_mutex);
 	int32_t ret(0), gain(0);
 	gain = value;
+	SoapySDR_logf(SOAPY_SDR_DEBUG,"setGain RF %s, channel %d, gain %d", direction == SOAPY_SDR_RX ? "RX" : "TX", channel, gain);
 
 	if ( direction == SOAPY_SDR_RX )
 	{
@@ -361,6 +362,9 @@ void SoapyHackRF::setGain( const int direction, const size_t channel, const std:
 			_tx_stream.amp_gain=_current_amp;
 		}
 
+	if(	   ((direction == SOAPY_SDR_RX) && (_current_mode == HACKRF_TRANSCEIVER_MODE_RX))
+		|| ((direction == SOAPY_SDR_TX) && (_current_mode == HACKRF_TRANSCEIVER_MODE_TX))	)
+	{
 		if ( _dev != NULL )
 		{
 			int ret = hackrf_set_amp_enable( _dev, (_current_amp > 0)?1 : 0 );
@@ -369,6 +373,7 @@ void SoapyHackRF::setGain( const int direction, const size_t channel, const std:
 				SoapySDR::logf( SOAPY_SDR_ERROR, "hackrf_set_amp_enable(%f) returned %s", _current_amp, hackrf_error_name( (hackrf_error) ret ) );
 			}
 		}
+	}
 	}else if ( direction == SOAPY_SDR_RX and name == "LNA" )
 	{
 		_rx_stream.lna_gain = value;

--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -323,7 +323,7 @@ int SoapyHackRF::activateStream(
 			if(_current_amp != _rx_stream.amp_gain) {
 				_current_amp = _rx_stream.amp_gain;
 				SoapySDR_logf(SOAPY_SDR_DEBUG, "activateStream - Set RX amp gain to %d", _current_amp);
-				hackrf_set_amp_enable(_dev,_current_amp);
+				hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			}
 			
 			// IF Gain (LNA for RX; VGA_TX for TX)
@@ -365,7 +365,7 @@ int SoapyHackRF::activateStream(
 			_current_bandwidth=_rx_stream.bandwidth;
 			hackrf_set_baseband_filter_bandwidth(_dev,_current_bandwidth);
 			_current_amp=_rx_stream.amp_gain;
-			hackrf_set_amp_enable(_dev,_current_amp);
+			hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			hackrf_set_lna_gain(_dev,_rx_stream.lna_gain);
 			hackrf_set_vga_gain(_dev,_rx_stream.vga_gain);
 			hackrf_start_rx(_dev,_hackrf_rx_callback,(void *) this);
@@ -420,7 +420,7 @@ int SoapyHackRF::activateStream(
 			if(_current_amp != _tx_stream.amp_gain) {
 				_current_amp=_tx_stream.amp_gain;
 				SoapySDR_logf(SOAPY_SDR_DEBUG, "activateStream - Set TX amp gain to %d", _current_amp);
-				hackrf_set_amp_enable(_dev,_current_amp);
+				hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			}
 			
 			// IF Gain (LNA for RX, VGA_TX for TX)
@@ -458,7 +458,7 @@ int SoapyHackRF::activateStream(
 			_current_bandwidth=_tx_stream.bandwidth;
 			hackrf_set_baseband_filter_bandwidth(_dev,_current_bandwidth);
 			_current_amp=_rx_stream.amp_gain;
-			hackrf_set_amp_enable(_dev,_current_amp);
+			hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			hackrf_set_txvga_gain(_dev,_tx_stream.vga_gain);
 			hackrf_set_antenna_enable(_dev,_tx_stream.bias);
 			hackrf_start_tx(_dev,_hackrf_tx_callback,(void *) this);


### PR DESCRIPTION
More rigorous testing led to discovery of two obscure cases. The proposed fixes address those.
 
1) Fixed usage of hackrf_amp_enable; in my recently changed code and the previously seldom executed code.
2) Fixed amp switching iff direction == mode; when the setting for AMP is different for sink/source, and you change the setting for the NON-active direction, don't change the amp in the hackrf (until the direction/mode switches).

Should have caught these two the first time out - sorry.

