### PR TITLE
Fix edge case return value of writeStream()

### DIFF
--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -687,7 +687,12 @@ int SoapyHackRF::writeStream(
 	size_t handle;
 
 	int ret=this->acquireWriteBuffer(stream,handle,(void **)&_tx_stream.remainderBuff,timeoutUs);
-	if (ret<0)return ret;
+	if(ret < 0){
+		if((ret == SOAPY_SDR_TIMEOUT) && (samp_avail > 0)){
+			return samp_avail;
+		}
+		return ret;
+	}
 
 	_tx_stream.remainderHandle=handle;
 	_tx_stream.remainderSamps=ret;


### PR DESCRIPTION
When samp_avail samples are used to fill the remaining space in the current
buffer and release it, but then acquireWriteBuffer() times out and we can't
write the rest of the samples to a new buffer, return samp_avail so that the
caller knowns that some of the samples have been processed.