### PR TITLE
Fix edge case return value of readStream()

### DIFF
--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -622,8 +622,12 @@ int SoapyHackRF::readStream(
 	size_t handle;
 	int ret = this->acquireReadBuffer(stream, handle, (const void **)&_rx_stream.remainderBuff, flags, timeNs, timeoutUs);
 
-	if (ret < 0)
+	if (ret < 0){
+		if((ret == SOAPY_SDR_TIMEOUT) && (samp_avail > 0)){
+			return samp_avail;
+		}
 		return ret;
+	}
 
 	_rx_stream.remainderHandle=handle;
 	_rx_stream.remainderSamps=ret;


### PR DESCRIPTION
When samp_avail samples are read from the current buffer and we release it, but
then acquireReadBuffer() times out because there are no more ready buffers,
return samp_avail so that the caller knowns it has been given some samples.