### PR TITLE
BOARD_ID_INVALID changed to BOARD_ID_UNDETECTED in HackRF API

### DIFF
--- a/HackRF_Registration.cpp
+++ b/HackRF_Registration.cpp
@@ -40,7 +40,7 @@ static std::vector<SoapySDR::Kwargs> find_HackRF(const SoapySDR::Kwargs &args)
 		for (int i = 0; i < list->devicecount; i++) {
 		
 			hackrf_device* device = NULL;
-			uint8_t board_id = BOARD_ID_INVALID;
+			uint8_t board_id = BOARD_ID_UNDETECTED;
 			read_partid_serialno_t read_partid_serialno;
 
 			hackrf_device_list_open(list, i, &device);

--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -107,7 +107,7 @@ std::string SoapyHackRF::getDriverKey( void ) const
 std::string SoapyHackRF::getHardwareKey( void ) const
 {
 	std::lock_guard<std::mutex> lock(_device_mutex);
-	uint8_t board_id=BOARD_ID_INVALID;
+	uint8_t board_id=BOARD_ID_UNDETECTED;
 
 	hackrf_board_id_read(_dev,&board_id);
 


### PR DESCRIPTION
In https://github.com/greatscottgadgets/hackrf/commit/75e3137d55c4ec4597da5e71c740ebd4d8dcc126, the API for hardware detection has been changed. The meaning of `BOARD_ID_UNDETECTED` is not exactly the same as `BOARD_ID_INVALID`, but it has the same value (0xff) and seems to be appropriate for initializing `board_id`.

Since this is not backward compatible, I've marked this as Draft.

Since libhackrf is versioned only by tags or git commits, it is difficult to write an ifdef for this.