### PR TITLE
deactivate stream when closing stream

### DIFF
--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -254,6 +254,7 @@ SoapySDR::Stream *SoapyHackRF::setupStream(
 
 void SoapyHackRF::closeStream( SoapySDR::Stream *stream )
 {
+	this->deactivateStream(stream, 0, 0);
 	std::lock_guard<std::mutex> lock(_device_mutex);
 	if (stream == RX_STREAM) {
 		_rx_stream.clear_buffers();


### PR DESCRIPTION
This fixes a bug I observed when testing with GNU Radio: The HackRF remained in RX mode with the RX LED illuminated after completion of the flowgraph. This happened because `deactivateStream()` was never called and because `closeStream()` does not call `hackrf_stop_rx()`.

I'm not 100% sure that this is the best solution, but it is similar to how things are done in SoapyRTLSDR and looks reasonable to me. I don't anticipate any problems if `deactivateStream()` is called multiple times.

This also fixes a similar potential bug with stopping TX, but in my tests TX stopped because `hackrf_close()` was called by the `SoapyHackRF` destructor. I'm not sure why the destructor was called for TX but not for RX.