### PR TITLE
Add missing arguments to control RX & TX bias

### DIFF
--- a/HackRF_Settings.cpp
+++ b/HackRF_Settings.cpp
@@ -71,6 +71,8 @@ SoapyHackRF::SoapyHackRF( const SoapySDR::Kwargs &args )
 
 	_current_bandwidth=0;
 
+	_current_bias=false;
+
 	if (args.count("bias_tx"))
 		_tx_stream.bias = args.at("bias_tx") == "true";
 	
@@ -207,7 +209,8 @@ void SoapyHackRF::writeSetting(const std::string &key, const std::string &value)
 		_tx_stream.bias=(value=="true") ? true : false;
 
 		if (_current_mode==HACKRF_TRANSCEIVER_MODE_TX) {
-			int ret=hackrf_set_antenna_enable(_dev,_tx_stream.bias);
+			_current_bias=_tx_stream.bias;
+			int ret=hackrf_set_antenna_enable(_dev,_current_bias);
 			if(ret!=HACKRF_SUCCESS)
 				SoapySDR_logf(SOAPY_SDR_INFO,"Failed to apply antenna bias voltage (TX)");
 		}
@@ -217,7 +220,8 @@ void SoapyHackRF::writeSetting(const std::string &key, const std::string &value)
 		_rx_stream.bias=(value=="true") ? true : false;
 
 		if (_current_mode == HACKRF_TRANSCEIVER_MODE_RX) {
-			int ret=hackrf_set_antenna_enable(_dev,_rx_stream.bias);
+			_current_bias=_rx_stream.bias;
+			int ret=hackrf_set_antenna_enable(_dev,_current_bias);
 			if(ret!=HACKRF_SUCCESS)
 				SoapySDR_logf(SOAPY_SDR_INFO,"Failed to apply antenna bias voltage (RX)");
 		}

--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -338,7 +338,15 @@ int SoapyHackRF::activateStream(
 			}
 		}
 
-		SoapySDR_logf(SOAPY_SDR_DEBUG, "Start RX");
+		// Bias voltage. Since this setting may be provided as a device argument,
+		// it may not take effect until streaming is enabled for the first time.
+		if(_current_bias != _rx_stream.bias) {
+			_current_bias = _rx_stream.bias;
+			SoapySDR_logf(SOAPY_SDR_DEBUG, "activateStream - Set RX bias voltage to %s", _current_bias ? "enabled" : "disabled");
+			hackrf_set_antenna_enable(_dev,_current_bias);
+		}
+		
+		SoapySDR_logf(SOAPY_SDR_DEBUG, "Start RX", _current_bias);
 
 		//reset buffer tracking before streaming
 		{
@@ -346,8 +354,6 @@ int SoapyHackRF::activateStream(
 			_rx_stream.buf_head = 0;
 			_rx_stream.buf_tail = 0;
 		}
-
-		hackrf_set_antenna_enable(_dev,_rx_stream.bias);
 
 		int ret = hackrf_start_rx(_dev, _hackrf_rx_callback, (void *) this);
 		if (ret != HACKRF_SUCCESS) {
@@ -370,7 +376,8 @@ int SoapyHackRF::activateStream(
 			hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			hackrf_set_lna_gain(_dev,_rx_stream.lna_gain);
 			hackrf_set_vga_gain(_dev,_rx_stream.vga_gain);
-			hackrf_set_antenna_enable(_dev,_rx_stream.bias);
+			_current_bias = _rx_stream.bias;
+			hackrf_set_antenna_enable(_dev,_current_bias);
 			hackrf_start_rx(_dev,_hackrf_rx_callback,(void *) this);
 			ret=hackrf_is_streaming(_dev);
 		}
@@ -436,11 +443,17 @@ int SoapyHackRF::activateStream(
 				SoapySDR_logf(SOAPY_SDR_DEBUG, "activateStream - Set RX bandwidth to %d", _current_bandwidth);
 				hackrf_set_baseband_filter_bandwidth(_dev,_current_bandwidth);
 			}
+		}
 
+		// Bias voltage. Since this setting may be provided as a device argument,
+		// it may not take effect until streaming is enabled for the first time.
+		if(_current_bias != _tx_stream.bias) {
+			_current_bias = _tx_stream.bias;
+			SoapySDR_logf(SOAPY_SDR_DEBUG, "activateStream - Set TX bias voltage to %s", _current_bias ? "enabled" : "disabled");
+			hackrf_set_antenna_enable(_dev,_current_bias);
 		}
 
 		SoapySDR_logf( SOAPY_SDR_DEBUG, "Start TX" );
-		hackrf_set_antenna_enable(_dev,_tx_stream.bias);
 		int ret = hackrf_start_tx( _dev, _hackrf_tx_callback, (void *) this );
 		if (ret != HACKRF_SUCCESS)
 		{
@@ -463,7 +476,8 @@ int SoapyHackRF::activateStream(
 			_current_amp=_rx_stream.amp_gain;
 			hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			hackrf_set_txvga_gain(_dev,_tx_stream.vga_gain);
-			hackrf_set_antenna_enable(_dev,_tx_stream.bias);
+			_current_bias = _tx_stream.bias;
+			hackrf_set_antenna_enable(_dev,_current_bias);
 			hackrf_start_tx(_dev,_hackrf_tx_callback,(void *) this);
 			ret=hackrf_is_streaming(_dev);
 		}

--- a/HackRF_Streaming.cpp
+++ b/HackRF_Streaming.cpp
@@ -283,7 +283,6 @@ int SoapyHackRF::activateStream(
 	const long long timeNs,
 	const size_t numElems )
 {
-
 	if(stream == RX_STREAM){
 
 		std::lock_guard<std::mutex> lock(_device_mutex);
@@ -348,6 +347,8 @@ int SoapyHackRF::activateStream(
 			_rx_stream.buf_tail = 0;
 		}
 
+		hackrf_set_antenna_enable(_dev,_rx_stream.bias);
+
 		int ret = hackrf_start_rx(_dev, _hackrf_rx_callback, (void *) this);
 		if (ret != HACKRF_SUCCESS) {
 			SoapySDR::logf(SOAPY_SDR_ERROR, "hackrf_start_rx() failed -- %s", hackrf_error_name(hackrf_error(ret)));
@@ -369,6 +370,7 @@ int SoapyHackRF::activateStream(
 			hackrf_set_amp_enable(_dev,(_current_amp > 0)?1 : 0 );
 			hackrf_set_lna_gain(_dev,_rx_stream.lna_gain);
 			hackrf_set_vga_gain(_dev,_rx_stream.vga_gain);
+			hackrf_set_antenna_enable(_dev,_rx_stream.bias);
 			hackrf_start_rx(_dev,_hackrf_rx_callback,(void *) this);
 			ret=hackrf_is_streaming(_dev);
 		}
@@ -438,7 +440,7 @@ int SoapyHackRF::activateStream(
 		}
 
 		SoapySDR_logf( SOAPY_SDR_DEBUG, "Start TX" );
-
+		hackrf_set_antenna_enable(_dev,_tx_stream.bias);
 		int ret = hackrf_start_tx( _dev, _hackrf_tx_callback, (void *) this );
 		if (ret != HACKRF_SUCCESS)
 		{

--- a/SoapyHackRF.hpp
+++ b/SoapyHackRF.hpp
@@ -366,6 +366,8 @@ private:
 
 	uint8_t _current_amp;
 
+	bool _current_bias;
+
 	/// Mutex protecting all use of the hackrf device _dev and other instance variables.
 	/// Most of the hackrf API is thread-safe because it only calls libusb, however
 	/// the activateStream() method in this library can close and re-open the device,

--- a/SoapyHackRF.hpp
+++ b/SoapyHackRF.hpp
@@ -332,7 +332,7 @@ private:
 		double samplerate;
 		uint32_t bandwidth;
 		uint64_t frequency;
-
+		bool bias;
 		bool overflow;
 	};
 


### PR DESCRIPTION
Hi,

This is a temptative PR that implements settings **and** device arguments to control Bias T during TX and RX. They are called `bias_tx` and `bias_rx` respectively. The rationale behind this is that a setting named `bias_tx` already existed, and it made sense to keep separate settings (and device arguments) to configure this option.

Looking forward for your feedback,

